### PR TITLE
Fix for deck sort and berserk cards, auto select hash codes on focus

### DIFF
--- a/Battle.html
+++ b/Battle.html
@@ -80,7 +80,7 @@
                             <div>
                                 <div id="attacker-hash-container">
                                     <div><label for="deck1">Deck Hash:</label></div>
-                                    <input id="deck1" type="text" value=""><br />
+                                    <input id="deck1" type="text" value="" onfocus="$(this).select()"><br />
                                 </div>
                                 <input id="edit-player" type="button" onclick="load_deck_builder('player');" value="Edit" />
                                 <input id="load-player" type="button" onclick="loadDeck('#deck1');" value="Load" />
@@ -100,7 +100,7 @@
                                 <div id="defender-hash-container">
                                     <div>
                                         <div><label for="deck2">Enemy Deck Hash:</label></div>
-                                        <input type="text" id="deck2" value="">
+                                        <input type="text" id="deck2" value="" onfocus="$(this).select()">
                                     </div>
                                     <input id="edit-cpu" type="button" onclick="load_deck_builder('cpu');" value="Edit" />
                                     <input id="load-cpu" type="button" onclick="loadDeck('#deck2');" value="Load" />
@@ -230,7 +230,7 @@
                                     <input type="checkbox" class="table-cell" id="animations" name="animations"><label>Show Animations (Incomplete)</label>
                                 </div>
                                 <div class="table-cell">
-                                    
+
                                 </div>
                             </div>
                         </div>

--- a/DeckBuilder.html
+++ b/DeckBuilder.html
@@ -55,7 +55,7 @@
                         <div><b>Deck Hash:</b></div>
                         <div>
                             <div class="highlighter" id="hash_highlighter"></div>
-                            <input class="highlighted" id="hash" type="text" value="" size="100" onchange="hash_changed();" onpaste="hash_changed.debounce(100)();" />
+                            <input class="highlighted" id="hash" type="text" value="" size="100" onchange="hash_changed();" onpaste="hash_changed.debounce(100)();" onfocus="$(this).select()" />
                         </div>
                     </div>
                     <div style="margin:10px 0 10px 0"><a id="link" href="#"></a>&nbsp;</div>

--- a/Titans.html
+++ b/Titans.html
@@ -89,7 +89,7 @@
                             <div>
                                 <div id="attacker-hash-container">
                                     <div><label for="deck1">Deck Hash:</label></div>
-                                    <input id="deck1" type="text" value=""><br />
+                                    <input id="deck1" type="text" value="" onfocus="$(this).select()"><br />
                                 </div>
                                 <input id="edit-player" type="button" onclick="load_deck_builder('player');" value="Edit" />
                                 <input id="load-player" type="button" onclick="loadDeck('#deck1');" value="Load" />
@@ -108,7 +108,7 @@
                                 <div id="defender-hash-container">
                                     <div>
                                         <div><label for="deck2">Enemy Deck Hash:</label></div>
-                                        <input type="text" id="deck2" value="">
+                                        <input type="text" id="deck2" value="" onfocus="$(this).select()">
                                     </div>
                                     <input id="edit-cpu" type="button" onclick="load_deck_builder('cpu');" value="Edit" />
                                     <input id="load-cpu" type="button" onclick="loadDeck('#deck2');" value="Load" />

--- a/scripts/deckbuilder.js
+++ b/scripts/deckbuilder.js
@@ -120,7 +120,7 @@ var initDeckBuilder = function ()
             updateHighlights();
         }
     });
-    
+
     inventory = _GET('inventory');
 
     if (_DEFINED("spoilers")) {
@@ -720,7 +720,7 @@ var sortDeck = function ()
         if (compare) return compare;
         compare = (cardA.type - cardB.type);
         if (compare) return compare;
-        compare = compareByID(unitA, unitB);
+        compare = unitA.id - unitB.id;
         if (compare) return compare;
         compare = unitA.level - unitB.level;
         if (compare) return compare;
@@ -768,7 +768,7 @@ var addUnitToDeck = function (unit, htmlCard)
             $deck.append($htmlCard)
         }
     }
-    
+
     $htmlCard = $(htmlCard);
     if (fromInventory)
     {
@@ -852,7 +852,7 @@ var removeFromDeck = function (event)
         replaceCard($htmlCard, captain);
     } else {
         unit = deck.deck.splice(index - 1, 1)[0];
-        
+
         $htmlCard.remove();
         if (deck.deck.length < 15) {
             $deck.append("<div class='card blank'></div>");

--- a/scripts/simulator_base.js
+++ b/scripts/simulator_base.js
@@ -233,7 +233,7 @@ var SIMULATOR = {};
                 }
 
                 affected++;
-                
+
                 var protect_amt = protect;
                 if (!protect_amt) {
                     var mult = skill.mult;
@@ -1162,7 +1162,7 @@ var SIMULATOR = {};
             if (skill.c && affected > 0) {
                 skill.countdown = skill.c;
             }
-            
+
             if (showAnimations) {
                 drawField(field, null, null, turn, src_card);
             }
@@ -1172,7 +1172,7 @@ var SIMULATOR = {};
     function initializeBattle() {
 
         SIMULATOR.simulation_turns = 0;
-        
+
         // Set up empty decks
         var deck = {
             cpu: {
@@ -1556,7 +1556,7 @@ var SIMULATOR = {};
         }
         if (choice === undefined) {
             return -1;
-            
+
         } else {
             var card_picked = choice;
             if (!card_picked) card_picked = 0;
@@ -1683,7 +1683,7 @@ var SIMULATOR = {};
 
         // Do Commander Early Activation Skills
         doEarlyActivationSkills(field_p.commander);
-        
+
         // Reset invisibility count after enhance has had a chance to fire
         for (var key = 0, len = field_p_assaults.length; key < len; key++) {
             var current_assault = field_p_assaults[key];
@@ -2101,7 +2101,7 @@ var SIMULATOR = {};
             if (current_assault.berserk && current_assault.isAlive()) {
 
                 var berserk = current_assault.berserk;
-                var enhanced = getEnhancement(target, 'berserk');
+                var enhanced = getEnhancement(current_assault, 'berserk');
                 if (enhanced) {
                     if (enhanced < 0) {
                         enhanced = Math.ceil(berserk * -enhanced);
@@ -2173,7 +2173,7 @@ var SIMULATOR = {};
                 if (debug) echo += debug_name(current_assault) + ' inflicts nullify(' + nullify + ') on ' + debug_name(target) + '<br>';
             }
         }
-        
+
         if (showAnimations) {
             drawField(field, null, null, turn, current_assault);
         }


### PR DESCRIPTION
FIXED: User cards with Berserk skill are now using correct value to gain
attack.
FIXED: Deck builder should sort cards as seen in game, Game is sorting card ids from low to high including fused cards.
ADD: When you focus on a Deck Hash box, code will be selected automatically.