### PR TITLE
Equate rankings for L4 champions and standard legendaries.

### DIFF
--- a/scripts/simulator_base.js
+++ b/scripts/simulator_base.js
@@ -2250,7 +2250,7 @@ var SIMULATOR = {};
 		} else {
 			var rarity = parseInt(card.rarity) * 5;
 			var level = card.level;
-			return rarity + 5 + level;
+			return rarity + 6 + level;
 		}
 	}
 

--- a/scripts/simulator_base.js
+++ b/scripts/simulator_base.js
@@ -11,6 +11,8 @@ var SIMULATOR = {};
 
 		var newKey = field_p_assaults.length;
 		initializeCard(card, p, newKey);
+                if (turn == 1) card.timer += 2;     // arena
+
 		card.played = true;
 
 		if (card.isAssault()) {

--- a/scripts/simulator_base.js
+++ b/scripts/simulator_base.js
@@ -11,7 +11,10 @@ var SIMULATOR = {};
 
 		var newKey = field_p_assaults.length;
 		initializeCard(card, p, newKey);
-                if (turn == 1) card.timer += 2;     // arena
+                if (turn == 1) { // arena
+		  if ((debug || play_debug) && !quiet) echo += 'ARENA MECHANICS: ' + debug_name(card) + ' delayed by 2<br>';
+                  card.timer += 2;
+                }
 
 		card.played = true;
 
@@ -2030,7 +2033,7 @@ var SIMULATOR = {};
 			if (current_assault.timer > 0) {
 				if (turn !== 3 || !tournament) {
 					current_assault.timer--;
-					if (debug) echo += debug_name(current_assault) + ' reduces its timer<br>';
+					if (debug) echo += debug_name(current_assault) + ' reduces its timer to ' + current_assault.timer + '<br>';
 				}
 			}
 


### PR DESCRIPTION
Trials suggest that the game AI has equal preference for playing **level 4** legendary champions and standard legendary cards.  The simulator currently equates **level 5** legendary champions with standard legendary cards.  This edit boosts the "ranking" of champions by a single point so that parity with standard cards is reached at level 4, matching behaviour observed in the game.