### PR TITLE
Bugfix/50/fix wingward

### DIFF
--- a/scripts/simulator_base.js
+++ b/scripts/simulator_base.js
@@ -470,12 +470,13 @@ var SIMULATOR = {};
 			for (var key = 0, len = targets.length; key < len; key++) {
 				var target = alliedUnits[targets[key]];
 				target.protected += wingward;
-				target.invisible += Math.ceil(wingward/2);
+				var invisBoost = Math.ceil(wingward/2);
+				target.invisible += invisBoost;
 				if (debug) {
 					if (enhanced) echo += '<u>(Enhance: +' + enhanced + ')</u><br>';
 					echo += debug_name(src_card) + ' wing guards ' + debug_name(target) + 
 						', protecting it by ' + wingward + 
-						' and imbuing it with invisible ' + wingward;
+						' and imbuing it with invisible ' + invisBoost;
 					echo += '<br>';
 				}
 			}

--- a/scripts/simulator_base.js
+++ b/scripts/simulator_base.js
@@ -452,11 +452,11 @@ var SIMULATOR = {};
 
 			var alliedUnits = getAlliedUnits(src_card, field);
 
-			// Targets self and leftmost ally
+			// Targets self and first ally from the left
 			var targets = [];
-			for (var key = 0; key < src_card.key; key++) {
+			for (var key = 0; key < alliedUnits.length; key++) {
 				var target = alliedUnits[key];
-				if (target.isAlive()) {
+				if (target.isAlive() && target != src_card) {
 					targets.push(key);
 					break;
 				}


### PR DESCRIPTION
This PR corrects two issues with Wingward:
1. When there are no allies to the left of Verus, it should find the first ally to it's right (essentially just find the left-most ally, even if they are not _to the left of Verus_).
2. When logging the amount of invisibility added, the log message was using the barrier value instead.

Fixes #50