### PR TITLE
chore: Disable branch builds other than gh-pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ addons:
 branches:
   only:
   - gh-pages
-  - /.*/
 cache:
   # Caches $HOME/.npm when npm ci is default script command
   # Caches node_modules in all other cases


### PR DESCRIPTION
Only `gh-pages` should kick off builds on the branch.  Other branches should only be built via pull-request builds.

This is currently causing duplicate builds on PRs made from branches within the repo, while PRs from forks only have the PR build.