### PR TITLE
Update assets URL/version

### DIFF
--- a/LINQ/DownloadAssetts.linq
+++ b/LINQ/DownloadAssetts.linq
@@ -4,8 +4,8 @@
 
 static string folder = Path.Combine(Path.GetDirectoryName(Util.CurrentQueryPath), "../Downloads");
 static DirectoryInfo directory = new DirectoryInfo(folder);
-static string baseURL = "https://d3splaxnu2bep2.cloudfront.net/spellstone/asset_bundles_live/2020_3_33f1/";
-static string fileVersion = "_unity2020_3_33_webgl.unity3d";
+static string baseURL = "https://d3splaxnu2bep2.cloudfront.net/spellstone/asset_bundles/2020_3_42f1/";
+static string fileVersion = "_unity2020_3_42_webgl.unity3d";
 static WebClient client = new WebClient();
 static bool downloadFiles = true;
 static bool runExtraction = true;

--- a/LINQ/head.mjs
+++ b/LINQ/head.mjs
@@ -12,7 +12,7 @@ async function head(url = '') {
     });
 }
 
-var url = 'https://d3splaxnu2bep2.cloudfront.net/spellstone/asset_bundles_live/2020_3_33f1/cardpack_002_unity2020_3_33_webgl.unity3d';
+var url = 'https://d3splaxnu2bep2.cloudfront.net/spellstone/asset_bundles/2020_3_42f1/cardpack_002_unity2020_3_42_webgl.unity3d';
 
 var resp = await head(url);
 


### PR DESCRIPTION
There was some confusion upon pushing the new bge assets with a different URL - some clients were also using the old one so new cards weren't visible even in the game.
Now all clients use the new URL.

Enables downloading of assets:
- New cardpack_event_099 (Insect BGE)
- Updated portraitpack_007 (Portrait_mythic_mecha) - this pack is being reused regularly to add new portraits.