### PR TITLE
Fix API call for image update

### DIFF
--- a/.github/actions/download-files/dist/index.mjs
+++ b/.github/actions/download-files/dist/index.mjs
@@ -2813,6 +2813,9 @@ async function determineChanges(user_id, password) {
         message: 'init',
         user_id,
         password,
+        unity: 'Unity2020_3_42',
+        platform: 'web',
+        client_version: '70'
     });
     const assetBundles = {};
     Object.values(initData.asset_bundles)

--- a/.github/actions/download-files/dist/index.mjs
+++ b/.github/actions/download-files/dist/index.mjs
@@ -2857,6 +2857,7 @@ async function callApi(payload) {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
+            'User-Agent': 'Mozilla/5.0'
         }
     };
     return new Promise((resolve, reject) => {

--- a/.github/actions/download-files/src/downloads/determineChanges.mjs
+++ b/.github/actions/download-files/src/downloads/determineChanges.mjs
@@ -56,6 +56,7 @@ async function callApi(payload) {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
+            'User-Agent': 'Mozilla/5.0'
         }
     };
     return new Promise((resolve, reject) => {

--- a/.github/actions/download-files/src/downloads/determineChanges.mjs
+++ b/.github/actions/download-files/src/downloads/determineChanges.mjs
@@ -11,6 +11,8 @@ export async function determineChanges(user_id, password) {
         user_id,
         password,
         unity: 'Unity2020_3_42',
+        platform: 'web',
+        client_version: '70'
     });
     const assetBundles = {};
     Object.values(initData.asset_bundles)


### PR DESCRIPTION
The game API returns a 403 if no 'User-Agent' is set in the request header.
Also including some parameters to ensure the list of bundle files will have the updated type/version.
This should enable catching up with the last two BGE assets (Avians/Undeads).